### PR TITLE
修复stock.get_quote_history无法获取数据或数据异常

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+.vscode/
 
 docs/build/
 efinance/data

--- a/efinance/common/getter.py
+++ b/efinance/common/getter.py
@@ -182,6 +182,7 @@ def get_quote_history(
     end: str = '20500101',
     klt: int = 101,
     fqt: int = 1,
+    lmt: int = 100,
     **kwargs,
 ) -> Union[pd.DataFrame, Dict[str, pd.DataFrame]]:
     """
@@ -226,7 +227,7 @@ def get_quote_history(
 
     if isinstance(codes, str):
         return get_quote_history_single(
-            codes, beg=beg, end=end, klt=klt, fqt=fqt, **kwargs
+            codes, beg=beg, end=end, klt=klt, fqt=fqt, lmt=lmt, **kwargs
         )
 
     elif hasattr(codes, '__iter__'):

--- a/efinance/common/getter.py
+++ b/efinance/common/getter.py
@@ -24,6 +24,7 @@ from .config import (
 import warnings
 warnings.filterwarnings("once")
 
+
 @to_numeric
 def get_realtime_quotes_by_fs(fs: str, **kwargs) -> pd.DataFrame:
     """
@@ -36,7 +37,8 @@ def get_realtime_quotes_by_fs(fs: str, **kwargs) -> pd.DataFrame:
 
     """
 
-    columns = {**EASTMONEY_QUOTE_FIELDS, **kwargs.get(MagicConfig.EXTRA_FIELDS, {})}
+    columns = {**EASTMONEY_QUOTE_FIELDS, **
+               kwargs.get(MagicConfig.EXTRA_FIELDS, {})}
     fields = ",".join(columns.keys())
     params = (
         ('pn', '1'),
@@ -57,7 +59,8 @@ def get_realtime_quotes_by_fs(fs: str, **kwargs) -> pd.DataFrame:
     df = df.rename(columns=columns)
     df: pd.DataFrame = df[columns.values()]
     df['行情ID'] = df['市场编号'].astype(str) + '.' + df['代码'].astype(str)
-    df['市场类型'] = df['市场编号'].astype(str).apply(lambda x: MARKET_NUMBER_DICT.get(x))
+    df['市场类型'] = df['市场编号'].astype(str).apply(
+        lambda x: MARKET_NUMBER_DICT.get(x))
     df['更新时间'] = df['更新时间戳'].apply(lambda x: str(datetime.fromtimestamp(x)))
     df['最新交易日'] = pd.to_datetime(df['最新交易日'], format='%Y%m%d').astype(str)
     tmp = df['最新交易日']
@@ -74,6 +77,7 @@ def get_quote_history_single(
     end: str = '20500101',
     klt: int = 101,
     fqt: int = 1,
+    lmt: int = 100,
     **kwargs,
 ) -> pd.DataFrame:
     """
@@ -88,16 +92,29 @@ def get_quote_history_single(
         quote_id = code
     else:
         quote_id = get_quote_id(code)
-    params = (
-        ('fields1', 'f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13'),
-        ('fields2', fields2),
-        ('beg', beg),
-        ('end', end),
-        ('rtntype', '6'),
-        ('secid', quote_id),
-        ('klt', f'{klt}'),
-        ('fqt', f'{fqt}'),
-    )
+    if klt < 101:
+        params = (
+            ("fields1", "f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13"),
+            ("fields2", fields2),
+            # ("beg", beg),
+            ("end", "20500101"),
+            ("rtntype", "6"),
+            ("secid", quote_id),
+            ("klt", f"{klt}"),
+            ("fqt", f"{fqt}"),
+            ("lmt", f"{lmt}"),
+        )
+    else:
+        params = (
+            ('fields1', 'f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13'),
+            ('fields2', fields2),
+            ('beg', beg),
+            ('end', end),
+            ('rtntype', '6'),
+            ('secid', quote_id),
+            ('klt', f'{klt}'),
+            ('fqt', f'{fqt}'),
+        )
 
     url = 'https://push2his.eastmoney.com/api/qt/stock/kline/get'
 
@@ -330,7 +347,8 @@ def get_base_info(quote_id: str) -> pd.Series:
     if not items:
         return pd.Series(index=EASTMONEY_BASE_INFO_FIELDS.values(), dtype='object')
 
-    s = pd.Series(items, dtype='object').rename(index=EASTMONEY_BASE_INFO_FIELDS)
+    s = pd.Series(items, dtype='object').rename(
+        index=EASTMONEY_BASE_INFO_FIELDS)
     return s
 
 
@@ -412,7 +430,8 @@ def get_latest_quote(quote_id_list: Union[str, List[str]], **kwargs) -> pd.DataF
         quote_id_list = [quote_id_list]
     secids: List[str] = quote_id_list
 
-    columns = {**EASTMONEY_QUOTE_FIELDS, **kwargs.get(MagicConfig.EXTRA_FIELDS, {})}
+    columns = {**EASTMONEY_QUOTE_FIELDS, **
+               kwargs.get(MagicConfig.EXTRA_FIELDS, {})}
     fields = ",".join(columns.keys())
     params = (
         ('OSVersion', '14.3'),

--- a/efinance/stock/getter.py
+++ b/efinance/stock/getter.py
@@ -163,6 +163,7 @@ def get_quote_history(
     end: str = '20500101',
     klt: int = 101,
     fqt: int = 1,
+    lmt: int = 100,
     **kwargs,
 ) -> Union[pd.DataFrame, Dict[str, pd.DataFrame]]:
     """
@@ -243,14 +244,15 @@ def get_quote_history(
 
     """
     df = get_quote_history_for_stock(
-        stock_codes, beg=beg, end=end, klt=klt, fqt=fqt, **kwargs
+        stock_codes, beg=beg, end=end, klt=klt, fqt=fqt, lmt=lmt, **kwargs
     )
     if isinstance(df, pd.DataFrame):
 
         df.rename(columns={'代码': '股票代码', '名称': '股票名称'}, inplace=True)
     elif isinstance(df, dict):
         for stock_code in df.keys():
-            df[stock_code].rename(columns={'代码': '股票代码', '名称': '股票名称'}, inplace=True)
+            df[stock_code].rename(
+                columns={'代码': '股票代码', '名称': '股票名称'}, inplace=True)
     return df
 
 
@@ -592,7 +594,8 @@ def get_top10_stock_holder_info(stock_code: str, top: int = 4) -> pd.DataFrame:
         url = 'https://emh5.eastmoney.com/api/GuBenGuDong/GetShiDaLiuTongGuDong'
         response = requests.post(url, json=data)
         response.encoding = 'utf-8'
-        items: List[dict] = jsonpath(response.json(), f'$..ShiDaLiuTongGuDongList[:]')
+        items: List[dict] = jsonpath(
+            response.json(), f'$..ShiDaLiuTongGuDongList[:]')
         if not items:
             continue
         df = pd.DataFrame(items)
@@ -669,7 +672,8 @@ def get_all_report_dates() -> pd.DataFrame:
         ('ps', '2000'),
     )
     url = 'https://datacenter.eastmoney.com/securities/api/data/get'
-    response = requests.get(url, headers=EASTMONEY_REQUEST_HEADERS, params=params)
+    response = requests.get(
+        url, headers=EASTMONEY_REQUEST_HEADERS, params=params)
     items = jsonpath(response.json(), '$..data[:]')
     if not items:
         pd.DataFrame(columns=fields.values())
@@ -777,10 +781,12 @@ def get_all_company_performance(date: str = None) -> pd.DataFrame:
             ('sty', 'ALL'),
             ('token', '894050c76af8597a853f5b408b759f5d'),
             # ! 只选沪深A股
-            ('filter', f'(SECURITY_TYPE_CODE in ("058001001","058001008")){date}'),
+            ('filter',
+             f'(SECURITY_TYPE_CODE in ("058001001","058001008")){date}'),
         )
         url = 'http://datacenter-web.eastmoney.com/api/data/get'
-        response = session.get(url, headers=EASTMONEY_REQUEST_HEADERS, params=params)
+        response = session.get(
+            url, headers=EASTMONEY_REQUEST_HEADERS, params=params)
         items = jsonpath(response.json(), '$..data[:]')
         if not items:
             break
@@ -901,7 +907,8 @@ def get_latest_holder_number(date: str = None) -> pd.DataFrame:
 
         params = tuple(params)
         url = 'http://datacenter-web.eastmoney.com/api/data/v1/get'
-        response = session.get(url, headers=EASTMONEY_REQUEST_HEADERS, params=params)
+        response = session.get(
+            url, headers=EASTMONEY_REQUEST_HEADERS, params=params)
         items = jsonpath(response.json(), '$..data[:]')
         if not items:
             break
@@ -1012,7 +1019,8 @@ def get_daily_billboard(start_date: str = None, end_date: str = None) -> pd.Data
                 ('columns', 'ALL'),
                 ('source', 'WEB'),
                 ('client', 'WEB'),
-                ('filter', f"(TRADE_DATE<='{end_date}')(TRADE_DATE>='{start_date}')"),
+                ('filter',
+                 f"(TRADE_DATE<='{end_date}')(TRADE_DATE>='{start_date}')"),
             )
 
             url = 'http://datacenter-web.eastmoney.com/api/data/v1/get'
@@ -1321,7 +1329,7 @@ def get_quote_snapshot(stock_code: str) -> pd.Series:
     }
     s = pd.Series(index=columns.values(), dtype='object')
     try:
-        qd: dict = json.loads(response.text[start_index : end_index + 1])
+        qd: dict = json.loads(response.text[start_index: end_index + 1])
     except:
         return s
     if not qd.get('fivequote'):


### PR DESCRIPTION
修复 https://github.com/Micro-sheep/efinance/issues/130  这个 issue

## 原因：

当 低于 klt 低于 101 的时候，如 60,30 分钟线，触发的是以下 get 请求
http://35.push2his.eastmoney.com/api/qt/stock/kline/get?secid=1.600900&fields1=f1%2Cf2%2Cf3%2Cf4%2Cf5%2Cf6&fields2=f51%2Cf52%2Cf53%2Cf54%2Cf55%2Cf56%2Cf57%2Cf58%2Cf59%2Cf60%2Cf61&klt=30&fqt=1&end=20500101&lmt=100

根据 url 分析，东方财富要求有个 lmt 参数（limit），同时 beg 和 end 参数不可自选，end 只能取默认最大值 20500101，通过改变 lmt 可以更改近几日的分钟线。目前 lmt 默认是 100 

## 测试 30 分钟线
df = ef.stock.get_quote_history("600900", beg="20200101", end="20230101", klt=30, fqt=1,lmt=100)

可返回结果：
![image](https://github.com/Micro-sheep/efinance/assets/6481352/bb44f574-88fe-43eb-8af6-668babc7fe92)

## 新增:

ef.stock.get_quote_history 可以传入 lmt 值来控制返回的数量
