### PR TITLE
fix get_all_company_performance

### DIFF
--- a/efinance/stock/getter.py
+++ b/efinance/stock/getter.py
@@ -741,7 +741,9 @@ def get_all_company_performance(date: str = None) -> pd.DataFrame:
     fields = {
         'SECURITY_CODE': '股票代码',
         'SECURITY_NAME_ABBR': '股票简称',
-        'NOTICE_DATE': '公告日期',
+        'REPORTDATE':'报告日期',
+        'UPDATE_DATE':'更新日期',
+        # 'NOTICE_DATE': '公告日期',
         'TOTAL_OPERATE_INCOME': '营业收入',
         'YSTZ': '营业收入同比增长',
         'YSHZ': '营业收入季度环比',
@@ -752,7 +754,9 @@ def get_all_company_performance(date: str = None) -> pd.DataFrame:
         'BPS': '每股净资产',
         'WEIGHTAVG_ROE': '净资产收益率',
         'XSMLL': '销售毛利率',
-        'MGJYXJJE': '每股经营现金流量'
+        'MGJYXJJE': '每股经营现金流量',
+        'DATATYPE': '数据类型',
+        'DATAYEAR': '数据年份',
         # 'ISNEW':'是否最新'
     }
 


### PR DESCRIPTION
修复 https://github.com/Micro-sheep/efinance/issues/109 的问题。

## 原因
http://datacenter-web.eastmoney.com/api/data/get?st=NOTICE_DATE%2CSECURITY_CODE&sr=-1%2C-1&ps=500&p=1&type=RPT_LICO_FN_CPD&sty=ALL&token=894050c76af8597a853f5b408b759f5d&filter=%28SECURITY_TYPE_CODE+in+%28%22058001001%22%2C%22058001008%22%29%29%28REPORTDATE%3D%272013-12-31%27%29

本身结果正常，只不过NOTICE_DATE的时间和UPDATE_DATE的时间一样，算最后更新时间。

报告正确时间应该是返回结果中的REPORTDATE。

## 修复方法

返回的结果删除了NOTICE_DATE，新增了REPORTDATE，UPDATE_DATE，DATATYPE，DATAYEAR四个字段来更好的展示数据年份。
![image](https://github.com/Micro-sheep/efinance/assets/6481352/d8e05af2-ff11-4867-9c36-481d0053c66c)
